### PR TITLE
Create dreamy board layout with video-playing cards

### DIFF
--- a/silly-lab/src/App.css
+++ b/silly-lab/src/App.css
@@ -1,42 +1,264 @@
+:root {
+  color-scheme: light;
+  font-family: 'Alegreya Sans', 'Trebuchet MS', system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #0f1115;
+}
+
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
+  min-height: 100vh;
+}
+
+.stage {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 10% 20%, rgba(255, 214, 239, 0.35), transparent 45%),
+    radial-gradient(circle at 90% 20%, rgba(200, 240, 255, 0.3), transparent 50%),
+    radial-gradient(circle at 50% 80%, rgba(177, 221, 255, 0.35), transparent 45%),
+    #0f1115;
+}
+
+.board {
+  width: min(1100px, 100%);
+  padding: 3rem clamp(1.5rem, 4vw, 4rem) 4rem;
+  border-radius: 32px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(247, 241, 232, 0.92));
+  box-shadow: 0 30px 60px rgba(12, 18, 28, 0.35);
+  position: relative;
+  overflow: hidden;
+}
+
+.board::before,
+.board::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.board::before {
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600" fill="none" stroke="%238f8a84" stroke-width="2" opacity="0.4"><path d="M120 140c40-30 80-30 120 0"/><path d="M620 140c40-30 80-30 120 0"/><path d="M180 420c50-40 110-40 160 0"/><path d="M470 420c50-40 110-40 160 0"/><circle cx="440" cy="260" r="48"/><path d="M415 260h50"/><path d="M440 236v50"/><path d="M320 250c-40 30-40 80 0 110"/><path d="M560 250c40 30 40 80 0 110"/><path d="M120 300l40 20 40-20 40 20"/><path d="M700 300l40 20 40-20 40 20"/><path d="M360 140l20 30 40-10"/><path d="M520 140l20 30 40-10"/></svg>')
+    center/cover no-repeat;
+  opacity: 0.35;
+}
+
+.board::after {
+  background: radial-gradient(circle at 20% 25%, rgba(255, 255, 255, 0.7), transparent 55%),
+    radial-gradient(circle at 70% 60%, rgba(255, 255, 255, 0.65), transparent 55%);
+  mix-blend-mode: screen;
+}
+
+.board-header {
+  position: relative;
+  z-index: 1;
+  max-width: 520px;
+  margin-bottom: 3rem;
+  color: #2f2a2f;
+}
+
+.eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  margin: 0 0 0.5rem;
+  color: rgba(47, 42, 47, 0.65);
+}
+
+h1 {
+  font-size: clamp(2.3rem, 4vw, 3.4rem);
+  margin: 0 0 1rem;
+}
+
+.board-header p {
+  margin: 0 0 1rem;
+  line-height: 1.5;
+}
+
+.filename {
+  font-weight: 600;
+}
+
+.card-row {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  position: relative;
+  z-index: 1;
+}
+
+.dream-card {
+  position: relative;
+  border: none;
+  padding: 1.8rem 1.5rem 2.2rem;
+  border-radius: 26px;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.7);
+  color: #2d2a2a;
+  box-shadow: 0 20px 35px rgba(30, 29, 41, 0.2);
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  min-height: 270px;
+}
+
+.dream-card:hover {
+  transform: translateY(-10px) scale(1.02);
+  box-shadow: 0 30px 45px rgba(30, 29, 41, 0.25);
+}
+
+.card-glow {
+  position: absolute;
+  inset: -30% -10% auto;
+  height: 60%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.9), transparent 70%);
+  opacity: 0.8;
+}
+
+.card-art {
+  width: 90px;
+  height: 90px;
+  border-radius: 18px;
+  border: 3px solid rgba(0, 0, 0, 0.65);
+  position: relative;
+  margin-bottom: 1.5rem;
+  background: #fdf7f1;
+  box-shadow: inset 0 0 0 3px rgba(255, 255, 255, 0.7);
+}
+
+.dream-card--dreamscape .card-art::before {
+  content: '';
+  position: absolute;
+  inset: 10px 12px auto 12px;
+  height: 32px;
+  border-radius: 20px 20px 4px 4px;
+  border: 3px solid rgba(0, 0, 0, 0.65);
+  border-bottom: none;
+}
+
+.dream-card--dreamscape .card-art::after {
+  content: '';
+  position: absolute;
+  inset: 48px 14px 12px 14px;
+  border: 3px solid rgba(0, 0, 0, 0.65);
+  border-top: none;
+  clip-path: polygon(0 0, 50% 50%, 100% 0, 100% 100%, 0 100%);
+}
+
+.dream-card--all-seeing .card-art::before {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border-radius: 50%;
+  border: 3px solid rgba(0, 0, 0, 0.7);
+  box-shadow: inset 0 0 0 12px rgba(0, 0, 0, 0.75);
+}
+
+.dream-card--wanderer .card-art {
+  background: #1f1b23;
+  border-color: #111015;
+}
+
+.dream-card--wanderer .card-art::before {
+  content: '';
+  position: absolute;
+  inset: 18px 30px 18px 30px;
+  border-radius: 8px;
+  background: #f3f1f0;
+  box-shadow: 0 0 0 2px #f3f1f0;
+}
+
+.card-copy {
+  display: block;
+  margin-bottom: 1.5rem;
+}
+
+.card-title {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.card-desc {
+  display: block;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: rgba(45, 42, 42, 0.7);
+}
+
+.card-cta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(45, 42, 42, 0.7);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 11, 17, 0.6);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 10;
+  backdrop-filter: blur(6px);
+}
+
+.modal-surface {
+  width: min(900px, 100%);
+  background: #f7f2ed;
+  border-radius: 24px;
   padding: 2rem;
-  text-align: center;
+  box-shadow: 0 30px 50px rgba(12, 18, 28, 0.35);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.modal-header h2 {
+  margin: 0.4rem 0 0;
+}
+
+.close-btn {
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  background: #2d2a2a;
+  color: #f7f2ed;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.player {
+  width: 100%;
+  border-radius: 16px;
+  background: #0f1115;
+}
+
+@media (max-width: 700px) {
+  .board {
+    padding: 2.5rem 1.5rem 3rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .modal-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
   }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/silly-lab/src/App.jsx
+++ b/silly-lab/src/App.jsx
@@ -1,56 +1,78 @@
-import React, { useState } from 'react'
-import './index.css'
+import { useState } from 'react'
+import './App.css'
 
-const rows = ['Role', 'Persona', 'Core']
-const cols = ['Ordinary', 'Crisis (Now)', 'Transformed']
-
-function StatCell({ value, onClick }) {
-  const color = value > 0 ? 'text-green-600' : value < 0 ? 'text-red-600' : 'text-gray-800'
-  return (
-    <button
-      className={`w-20 h-20 border flex items-center justify-center ${color}`}
-      onClick={onClick}
-    >
-      {value}
-    </button>
-  )
-}
+const cards = [
+  {
+    id: 'dreamscape',
+    title: 'Dreamscape',
+    description: 'Soft hills and star paths shimmer in the mist.',
+  },
+  {
+    id: 'all-seeing',
+    title: 'All-Seeing',
+    description: 'A calm gaze that keeps the world in balance.',
+  },
+  {
+    id: 'wanderer',
+    title: 'Wanderer',
+    description: 'A tiny traveler on a dark, glowing tile.',
+  },
+]
 
 export default function App() {
-  const initial = Array.from({ length: 3 }, () => Array(3).fill(0))
-  const [grid, setGrid] = useState(initial)
-
-  const cycleValue = (r, c) => {
-    setGrid(prev =>
-      prev.map((row, ri) =>
-        row.map((val, ci) => {
-          if (ri === r && ci === c) {
-            const next = val + 1
-            return next > 3 ? -3 : next
-          }
-          return val
-        })
-      )
-    )
-  }
+  const [activeCard, setActiveCard] = useState(null)
 
   return (
-    <div className='p-4'>
-      <h1 className='text-2xl font-bold mb-4 text-center'>Silly Lab: Stat Grid Simulator</h1>
-      <div className='grid grid-cols-4 gap-2'>
-        <div></div>
-        {cols.map(col => (
-          <div key={col} className='text-center font-semibold'>{col}</div>
-        ))}
-        {rows.map((rowLabel, r) => (
-          <React.Fragment key={rowLabel}>
-            <div className='font-semibold flex items-center'>{rowLabel}</div>
-            {grid[r].map((val, c) => (
-              <StatCell key={c} value={val} onClick={() => cycleValue(r, c)} />
-            ))}
-          </React.Fragment>
-        ))}
+    <div className='stage'>
+      <div className='board'>
+        <header className='board-header'>
+          <p className='eyebrow'>Silly Prototype</p>
+          <h1>Dream Board</h1>
+          <p>
+            Choose a card to begin the Red Balloon scene. Drop your movie file at
+            <span className='filename'> /public/red-balloon.mp4</span>.
+          </p>
+        </header>
+
+        <section className='card-row'>
+          {cards.map(card => (
+            <button
+              key={card.id}
+              type='button'
+              className={`dream-card dream-card--${card.id}`}
+              onClick={() => setActiveCard(card)}
+            >
+              <span className='card-glow' aria-hidden='true' />
+              <span className='card-art' aria-hidden='true' />
+              <span className='card-copy'>
+                <span className='card-title'>{card.title}</span>
+                <span className='card-desc'>{card.description}</span>
+              </span>
+              <span className='card-cta'>Play Red Balloon</span>
+            </button>
+          ))}
+        </section>
       </div>
+
+      {activeCard ? (
+        <div className='modal' role='dialog' aria-modal='true'>
+          <div className='modal-surface'>
+            <div className='modal-header'>
+              <div>
+                <p className='eyebrow'>Now playing</p>
+                <h2>{activeCard.title}</h2>
+              </div>
+              <button type='button' className='close-btn' onClick={() => setActiveCard(null)}>
+                Close
+              </button>
+            </div>
+            <video className='player' controls autoPlay playsInline>
+              <source src='/red-balloon.mp4' type='video/mp4' />
+              Your browser does not support the video tag.
+            </video>
+          </div>
+        </div>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Replace the previous stat-grid demo with a simple, visual test environment where users can pick a floating dreamy card and play a movie called Red Balloon.

### Description
- Replaced the stat grid UI with a new interactive scene in `silly-lab/src/App.jsx` that defines three cards and opens a modal video player when a card is clicked.
- Added `silly-lab/src/App.css` containing styling for the stage, board background (SVG doodles + gradients), dreamy card art, and modal player presentation.
- The modal uses a `<video>` element sourcing `/red-balloon.mp4` and cards are `dreamscape`, `all-seeing`, and `wanderer` with individual visual treatments.
- Removed the old stat-grid logic and updated the component to use `App.css` instead of the prior grid styles.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready (local and network URLs). 
- Captured a UI screenshot by running a Playwright script against `http://127.0.0.1:4173/`, which produced `artifacts/dream-board.png` successfully. 
- No unit or integration test suites were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b1f14370832fa978e090187d9e0a)